### PR TITLE
refrain tcpinfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,12 @@ if err != nil {
 package main
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
-	"fmt"
 	"net"
 	"sync"
+
 	"github.com/brucespang/go-tcpinfo"
 )
 
@@ -30,14 +31,14 @@ func handleConn(conn net.Conn) {
 }
 
 func server(wg *sync.WaitGroup) {
-  ln,err := net.Listen("tcp", ":8000")
+	ln, err := net.Listen("tcp", ":8000")
 	if err != nil {
 		panic(err)
 	}
 
 	wg.Done()
 
-  // accept connection on port
+	// accept connection on port
 	for {
 		conn, err := ln.Accept()
 		if err != nil {
@@ -56,12 +57,12 @@ func client() {
 
 	go io.Copy(ioutil.Discard, conn)
 
-	_,err = conn.Write([]byte("hihihihihihihi"))
+	_, err = conn.Write([]byte("hihihihihihihi"))
 	if err != nil {
 		panic(err)
 	}
 
-	tcpInfo, err := tcpinfo.GetsockoptTCPInfo(&conn)
+	tcpInfo, err := tcpinfo.GetsockoptTCPInfo(conn.(*net.TCPConn))
 	if err != nil {
 		panic(err)
 	}
@@ -75,5 +76,6 @@ func main() {
 	wg.Wait()
 	client()
 }
+
 
 ```

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/brucespang/go-tcpinfo
+
+go 1.14

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/tcpinfo_test.go
+++ b/tcpinfo_test.go
@@ -1,0 +1,45 @@
+// +build linux
+
+package tcpinfo
+
+import (
+	"net"
+	"testing"
+)
+
+func TestGetsockoptTCPInfo(t *testing.T) {
+	var listAddr net.Addr
+	ch := make(chan error)
+	go func() {
+		addr, err := net.ResolveTCPAddr("tcp4", "127.0.0.1:0")
+		if err != nil {
+			ch <- err
+			return
+		}
+		l, err := net.ListenTCP("tcp4", addr)
+		if err != nil {
+			ch <- err
+			return
+		}
+		listAddr = l.Addr()
+		ch <- nil
+		_, _ = l.Accept()
+	}()
+
+	err := <-ch
+	if err != nil {
+		t.Error(err)
+	}
+	conn, err := net.DialTCP("tcp4", nil, listAddr.(*net.TCPAddr))
+	if err != nil {
+		t.Error(err)
+	}
+	tcpInfo, err := GetsockoptTCPInfo(conn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if tcpInfo.Rtt <= 0 {
+		t.Errorf("get tcpinfo failed. tcpInfo=%v", tcpInfo)
+	}
+}


### PR DESCRIPTION
1. use go.mod to maintain the repo
2. refrain tcpinfo.go
3. add testcase

ps. instead use net.Conn as a parameter, i think *net.TcpConn is better, as tcpinfo only used on tcp not other conn.