### PR TITLE
use RawConn.Control to get fd instead of Fd()

### DIFF
--- a/tcpinfo.go
+++ b/tcpinfo.go
@@ -16,17 +16,22 @@ func GetsockoptTCPInfo(tcpConn *net.TCPConn) (*TCPInfo, error) {
 		return nil, fmt.Errorf("tcp conn is nil")
 	}
 
-	file, err := tcpConn.File()
+	rawConn, err := tcpConn.SyscallConn()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error getting raw connection. err=%v", err)
 	}
-	defer file.Close()
 
-	fd := file.Fd()
 	tcpInfo := TCPInfo{}
 	size := unsafe.Sizeof(tcpInfo)
-	_, _, errno := syscall.Syscall6(syscall.SYS_GETSOCKOPT, fd, syscall.SOL_TCP, syscall.TCP_INFO,
-		uintptr(unsafe.Pointer(&tcpInfo)), uintptr(unsafe.Pointer(&size)), 0)
+	var errno syscall.Errno
+	err = rawConn.Control(func(fd uintptr) {
+		_, _, errno = syscall.Syscall6(syscall.SYS_GETSOCKOPT, fd, syscall.SOL_TCP, syscall.TCP_INFO,
+			uintptr(unsafe.Pointer(&tcpInfo)), uintptr(unsafe.Pointer(&size)), 0)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("rawconn control failed. err=%v", err)
+	}
+
 	if errno != 0 {
 		return nil, fmt.Errorf("syscall failed. errno=%d", errno)
 	}


### PR DESCRIPTION
file.Fd() has a potential bug when work with unblocking connection which is the default setting of Golang lib.
```
// Fd returns the integer Unix file descriptor referencing the open file.
// The file descriptor is valid only until f.Close is called or f is garbage collected.
// On Unix systems this will cause the SetDeadline methods to stop working.
func (f *File) Fd() uintptr {
	if f == nil {
		return ^(uintptr(0))
	}

	// If we put the file descriptor into nonblocking mode,
	// then set it to blocking mode before we return it,
	// because historically we have always returned a descriptor
	// opened in blocking mode. The File will continue to work,
	// but any blocking operation will tie up a thread.
	if f.nonblock {
		f.pfd.SetBlocking() // HERE!!!
	}

	return uintptr(f.pfd.Sysfd)
}
```
This will case tcpconn becoming blocking, and may case goroutine blocked at conn.Close().
check this link for more information: https://github.com/golang/go/issues/29277

So i use RawConn.Control which used in many Golang lib to do the syscall.